### PR TITLE
Fix ThemeProvider import and component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
-  import { useTheme } from '@/composables/useTheme';
+  import ThemeProvider from '@/components/ThemeProvider.vue';
   import LeTipHeader from '@/components/LeTipHeader.vue';
-
-  useTheme();
 </script>
 
 <template>

--- a/src/components/ThemeProvider.vue
+++ b/src/components/ThemeProvider.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { useTheme } from '@/composables/useTheme'
+useTheme()
+</script>
+
+<template>
+  <slot />
+</template>
+


### PR DESCRIPTION
## Summary
- create a simple `ThemeProvider` component
- import the provider inside `App.vue`

## Testing
- `npm run build` *(fails: run-p not found)*
- `npm run lint` *(fails: eslint-plugin-vue not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f4a0e075c832e9d5b40c0c0ba49fd